### PR TITLE
Add sequencer API and multi-soundfont-per-synth support

### DIFF
--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -17,6 +17,7 @@ extern "C" JNIEXPORT int JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_loadSoundfont(JNIEnv* env, jclass clazz, jstring path, jint bank, jint program) {
     settings[nextSfId] = new_fluid_settings();
     fluid_settings_setnum(settings[nextSfId], "synth.gain", 1.0);
+    // sayısal değerleri uygun setter ile ayarla
     fluid_settings_setint(settings[nextSfId], "audio.period-size", 64);
     fluid_settings_setint(settings[nextSfId], "audio.periods", 4);
     fluid_settings_setint(settings[nextSfId], "audio.realtime-prio", 99);
@@ -30,6 +31,7 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_loadSoundfont(
         fluid_synth_program_select(synths[nextSfId], i, sfId, bank, program);
     }
     env->ReleaseStringUTFChars(path, nativePath);
+    // Audio driver'ı en son oluştur
     drivers[nextSfId] = new_fluid_audio_driver(settings[nextSfId], synths[nextSfId]);
     soundfonts[nextSfId] = sfId;
     nextSfId++;
@@ -69,9 +71,10 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_stopNote(JNIEn
 extern "C" JNIEXPORT void JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_stopAllNotes(JNIEnv* env, jclass clazz, jint sfId) {
     if (synths.find(sfId) == synths.end()) return;
+    // Sustain'i kapat ve tüm kanallar için All Sound Off gönder
     for (int ch = 0; ch < 16; ++ch) {
-        fluid_synth_cc(synths[sfId], ch, 64, 0);
-        fluid_synth_all_sounds_off(synths[sfId], ch);
+        fluid_synth_cc(synths[sfId], ch, 64, 0); // Sustain off
+        fluid_synth_all_sounds_off(synths[sfId], ch); // Instant cut
     }
 }
 

--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -9,11 +9,14 @@ std::map<int, fluid_settings_t*> settings = {};
 std::map<int, int> soundfonts = {};
 int nextSfId = 1;
 
+// Sequencer state (one sequencer per synth, keyed by sfId)
+std::map<int, fluid_sequencer_t*> sequencers = {};
+std::map<int, fluid_seq_id_t> synthSeqIds = {};  // synth destination ID in sequencer
+
 extern "C" JNIEXPORT int JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_loadSoundfont(JNIEnv* env, jclass clazz, jstring path, jint bank, jint program) {
     settings[nextSfId] = new_fluid_settings();
     fluid_settings_setnum(settings[nextSfId], "synth.gain", 1.0);
-    // sayısal değerleri uygun setter ile ayarla
     fluid_settings_setint(settings[nextSfId], "audio.period-size", 64);
     fluid_settings_setint(settings[nextSfId], "audio.periods", 4);
     fluid_settings_setint(settings[nextSfId], "audio.realtime-prio", 99);
@@ -27,16 +30,30 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_loadSoundfont(
         fluid_synth_program_select(synths[nextSfId], i, sfId, bank, program);
     }
     env->ReleaseStringUTFChars(path, nativePath);
-    // Audio driver'ı en son oluştur
     drivers[nextSfId] = new_fluid_audio_driver(settings[nextSfId], synths[nextSfId]);
     soundfonts[nextSfId] = sfId;
     nextSfId++;
     return nextSfId - 1;
 }
 
+extern "C" JNIEXPORT int JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_loadSoundfontIntoSynth(JNIEnv* env, jclass clazz, jint existingSfId, jstring path, jint bank, jint program) {
+    if (synths.find(existingSfId) == synths.end()) return -1;
+    const char *nativePath = env->GetStringUTFChars(path, nullptr);
+    int fluidSfId = fluid_synth_sfload(synths[existingSfId], nativePath, 0);
+    env->ReleaseStringUTFChars(path, nativePath);
+    return fluidSfId;
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_selectInstrument(JNIEnv* env, jclass clazz, jint sfId, jint channel, jint bank, jint program) {
     fluid_synth_program_select(synths[sfId], channel, soundfonts[sfId], bank, program);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_selectInstrumentBySfontId(JNIEnv* env, jclass clazz, jint sfId, jint channel, jint fluidSfontId, jint bank, jint program) {
+    if (synths.find(sfId) == synths.end()) return;
+    fluid_synth_program_select(synths[sfId], channel, fluidSfontId, bank, program);
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -52,10 +69,9 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_stopNote(JNIEn
 extern "C" JNIEXPORT void JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_stopAllNotes(JNIEnv* env, jclass clazz, jint sfId) {
     if (synths.find(sfId) == synths.end()) return;
-    // Sustain'i kapat ve tüm kanallar için All Sound Off gönder
     for (int ch = 0; ch < 16; ++ch) {
-        fluid_synth_cc(synths[sfId], ch, 64, 0); // Sustain off
-        fluid_synth_all_sounds_off(synths[sfId], ch); // Instant cut
+        fluid_synth_cc(synths[sfId], ch, 64, 0);
+        fluid_synth_all_sounds_off(synths[sfId], ch);
     }
 }
 
@@ -76,6 +92,11 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_unloadSoundfon
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_dispose(JNIEnv* env, jclass clazz) {
+    for (auto const& x : sequencers) {
+        delete_fluid_sequencer(x.second);
+    }
+    sequencers.clear();
+    synthSeqIds.clear();
     for (auto const& x : synths) {
         delete_fluid_audio_driver(drivers[x.first]);
         delete_fluid_synth(synths[x.first]);
@@ -84,4 +105,51 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_dispose(JNIEnv
     synths.clear();
     drivers.clear();
     soundfonts.clear();
+}
+
+// --- Sequencer API ---
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_createSequencer(JNIEnv* env, jclass clazz, jint sfId) {
+    if (synths.find(sfId) == synths.end()) return;
+    fluid_sequencer_t* seq = new_fluid_sequencer2(1);  // use_system_timer=1
+    fluid_seq_id_t synthId = fluid_sequencer_register_fluidsynth(seq, synths[sfId]);
+    sequencers[sfId] = seq;
+    synthSeqIds[sfId] = synthId;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_getSequencerTick(JNIEnv* env, jclass clazz, jint sfId) {
+    if (sequencers.find(sfId) == sequencers.end()) return -1;
+    return (jint)fluid_sequencer_get_tick(sequencers[sfId]);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_scheduleNoteOn(JNIEnv* env, jclass clazz, jint sfId, jint tick, jint channel, jint key, jint velocity) {
+    if (sequencers.find(sfId) == sequencers.end()) return;
+    fluid_event_t* evt = new_fluid_event();
+    fluid_event_set_source(evt, -1);
+    fluid_event_set_dest(evt, synthSeqIds[sfId]);
+    fluid_event_noteon(evt, channel, (short)key, (short)velocity);
+    fluid_sequencer_send_at(sequencers[sfId], evt, (unsigned int)tick, 1);
+    delete_fluid_event(evt);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_scheduleNoteOff(JNIEnv* env, jclass clazz, jint sfId, jint tick, jint channel, jint key) {
+    if (sequencers.find(sfId) == sequencers.end()) return;
+    fluid_event_t* evt = new_fluid_event();
+    fluid_event_set_source(evt, -1);
+    fluid_event_set_dest(evt, synthSeqIds[sfId]);
+    fluid_event_noteoff(evt, channel, (short)key);
+    fluid_sequencer_send_at(sequencers[sfId], evt, (unsigned int)tick, 1);
+    delete_fluid_event(evt);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_deleteSequencer(JNIEnv* env, jclass clazz, jint sfId) {
+    if (sequencers.find(sfId) == sequencers.end()) return;
+    delete_fluid_sequencer(sequencers[sfId]);
+    sequencers.erase(sfId);
+    synthSeqIds.erase(sfId);
 }

--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -112,7 +112,7 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_dispose(JNIEnv
 extern "C" JNIEXPORT void JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_createSequencer(JNIEnv* env, jclass clazz, jint sfId) {
     if (synths.find(sfId) == synths.end()) return;
-    fluid_sequencer_t* seq = new_fluid_sequencer2(1);  // use_system_timer=1
+    fluid_sequencer_t* seq = new_fluid_sequencer2(0);  // use_system_timer=0: audio thread drives dispatch
     fluid_seq_id_t synthId = fluid_sequencer_register_fluidsynth(seq, synths[sfId]);
     sequencers[sfId] = seq;
     synthSeqIds[sfId] = synthId;

--- a/android/src/main/kotlin/com/melihhakanpektas/flutter_midi_pro/FlutterMidiProPlugin.kt
+++ b/android/src/main/kotlin/com/melihhakanpektas/flutter_midi_pro/FlutterMidiProPlugin.kt
@@ -40,11 +40,10 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
     private external fun stopAllNotes(sfId: Int)
 
     @JvmStatic
-    private external fun controlChange(sfId: Int, channel: Int, controller: Int, value: Int)
+  private external fun controlChange(sfId: Int, channel: Int, controller: Int, value: Int)
 
-    @JvmStatic
+  @JvmStatic
     private external fun unloadSoundfont(sfId: Int)
-
     @JvmStatic
     private external fun dispose()
 
@@ -82,13 +81,17 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
           val program = call.argument<Int>("program")?:0
           val audioManager = flutterPluginBinding.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
+          // Sesi mute yapma
           audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
 
+          // Soundfont yükleme işlemi (senkron, bloke eden çağrı)
           val sfId = loadSoundfont(path, bank, program)
           delay(250)
 
+          // Sesi tekrar açma
           audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, 0)
 
+          // Sonucu ana thread'de Flutter'a iletme
           withContext(Dispatchers.Main) {
             if (sfId == -1) {
               result.error("INVALID_ARGUMENT", "Something went wrong. Check the path of the template soundfont", null)

--- a/android/src/main/kotlin/com/melihhakanpektas/flutter_midi_pro/FlutterMidiProPlugin.kt
+++ b/android/src/main/kotlin/com/melihhakanpektas/flutter_midi_pro/FlutterMidiProPlugin.kt
@@ -22,7 +22,13 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
     private external fun loadSoundfont(path: String, bank: Int, program: Int): Int
 
     @JvmStatic
+    private external fun loadSoundfontIntoSynth(existingSfId: Int, path: String, bank: Int, program: Int): Int
+
+    @JvmStatic
     private external fun selectInstrument(sfId: Int, channel:Int, bank: Int, program: Int)
+
+    @JvmStatic
+    private external fun selectInstrumentBySfontId(sfId: Int, channel: Int, fluidSfontId: Int, bank: Int, program: Int)
 
     @JvmStatic
     private external fun playNote(channel: Int, key: Int, velocity: Int, sfId: Int)
@@ -34,12 +40,29 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
     private external fun stopAllNotes(sfId: Int)
 
     @JvmStatic
-  private external fun controlChange(sfId: Int, channel: Int, controller: Int, value: Int)
+    private external fun controlChange(sfId: Int, channel: Int, controller: Int, value: Int)
 
-  @JvmStatic
+    @JvmStatic
     private external fun unloadSoundfont(sfId: Int)
+
     @JvmStatic
     private external fun dispose()
+
+    // Sequencer API
+    @JvmStatic
+    private external fun createSequencer(sfId: Int)
+
+    @JvmStatic
+    private external fun getSequencerTick(sfId: Int): Int
+
+    @JvmStatic
+    private external fun scheduleNoteOn(sfId: Int, tick: Int, channel: Int, key: Int, velocity: Int)
+
+    @JvmStatic
+    private external fun scheduleNoteOff(sfId: Int, tick: Int, channel: Int, key: Int)
+
+    @JvmStatic
+    private external fun deleteSequencer(sfId: Int)
   }
 
   private lateinit var channel : MethodChannel
@@ -49,7 +72,7 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
     this.flutterPluginBinding = flutterPluginBinding
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_midi_pro")
     channel.setMethodCallHandler(this)
-  }  
+  }
  override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
     when (call.method) {
       "loadSoundfont" -> {
@@ -58,23 +81,43 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
           val bank = call.argument<Int>("bank")?:0
           val program = call.argument<Int>("program")?:0
           val audioManager = flutterPluginBinding.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-          
-          // Sesi mute yapma
+
           audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
-          
-          // Soundfont yükleme işlemi (senkron, bloke eden çağrı)
+
           val sfId = loadSoundfont(path, bank, program)
           delay(250)
-          
-          // Sesi tekrar açma
+
           audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, 0)
-          
-          // Sonucu ana thread'de Flutter'a iletme
+
           withContext(Dispatchers.Main) {
             if (sfId == -1) {
               result.error("INVALID_ARGUMENT", "Something went wrong. Check the path of the template soundfont", null)
             } else {
               result.success(sfId)
+            }
+          }
+        }
+      }
+      "loadSoundfontIntoSynth" -> {
+        CoroutineScope(Dispatchers.IO).launch {
+          val existingSfId = call.argument<Int>("existingSfId") as Int
+          val path = call.argument<String>("path") as String
+          val bank = call.argument<Int>("bank") ?: 0
+          val program = call.argument<Int>("program") ?: 0
+          val audioManager = flutterPluginBinding.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+          audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
+
+          val fluidSfId = loadSoundfontIntoSynth(existingSfId, path, bank, program)
+          delay(250)
+
+          audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, 0)
+
+          withContext(Dispatchers.Main) {
+            if (fluidSfId == -1) {
+              result.error("INVALID_ARGUMENT", "Failed to load soundfont into existing synth", null)
+            } else {
+              result.success(fluidSfId)
             }
           }
         }
@@ -87,6 +130,15 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
           selectInstrument(sfId, channel, bank, program)
           result.success(null)
         }
+      "selectInstrumentBySfontId" -> {
+        val sfId = call.argument<Int>("sfId") as Int
+        val channel = call.argument<Int>("channel") ?: 0
+        val fluidSfontId = call.argument<Int>("fluidSfontId") as Int
+        val bank = call.argument<Int>("bank") ?: 0
+        val program = call.argument<Int>("program") ?: 0
+        selectInstrumentBySfontId(sfId, channel, fluidSfontId, bank, program)
+        result.success(null)
+      }
       "playNote" -> {
         val channel = call.argument<Int>("channel")
         val key = call.argument<Int>("key")
@@ -134,6 +186,39 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
       }
       "dispose" -> {
         dispose()
+        result.success(null)
+      }
+      // Sequencer API
+      "createSequencer" -> {
+        val sfId = call.argument<Int>("sfId") as Int
+        createSequencer(sfId)
+        result.success(null)
+      }
+      "getSequencerTick" -> {
+        val sfId = call.argument<Int>("sfId") as Int
+        val tick = getSequencerTick(sfId)
+        result.success(tick)
+      }
+      "scheduleNoteOn" -> {
+        val sfId = call.argument<Int>("sfId") as Int
+        val tick = call.argument<Int>("tick") as Int
+        val channel = call.argument<Int>("channel") as Int
+        val key = call.argument<Int>("key") as Int
+        val velocity = call.argument<Int>("velocity") as Int
+        scheduleNoteOn(sfId, tick, channel, key, velocity)
+        result.success(null)
+      }
+      "scheduleNoteOff" -> {
+        val sfId = call.argument<Int>("sfId") as Int
+        val tick = call.argument<Int>("tick") as Int
+        val channel = call.argument<Int>("channel") as Int
+        val key = call.argument<Int>("key") as Int
+        scheduleNoteOff(sfId, tick, channel, key)
+        result.success(null)
+      }
+      "deleteSequencer" -> {
+        val sfId = call.argument<Int>("sfId") as Int
+        deleteSequencer(sfId)
         result.success(null)
       }
       else -> result.notImplemented()

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.7"
+    version: "3.1.5"
   flutter_piano_pro:
     dependency: "direct main"
     description:
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -275,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.5"
+    version: "3.1.7"
   flutter_piano_pro:
     dependency: "direct main"
     description:
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -275,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/lib/flutter_midi_pro.dart
+++ b/lib/flutter_midi_pro.dart
@@ -4,21 +4,32 @@ import 'package:flutter/services.dart';
 import 'package:flutter_midi_pro/flutter_midi_pro_platform_interface.dart';
 import 'package:path_provider/path_provider.dart';
 
+/// The FlutterMidiPro class provides functions for writing to and loading soundfont
+/// files, as well as playing and stopping MIDI notes.
+///
+/// To use this class, you must first call the [init] method. Then, you can load a
+/// soundfont file using the [loadSoundfont] method. After loading a soundfont file,
+/// you can select an instrument using the [selectInstrument] method. Finally, you
+/// can play and stop notes using the [playNote] and [stopNote] methods.
+///
+/// To stop all notes on a channel, you can use the [stopAllNotes] method.
+///
+/// To dispose of the FlutterMidiPro instance, you can use the [dispose] method.
 class MidiPro {
   MidiPro();
 
-  Future<int> loadSoundfontAsset(
-      {required String assetPath, int bank = 0, int program = 0}) async {
+  /// Loads a soundfont file from the specified asset path.
+  /// Returns the sfId (SoundfontSamplerId).
+  Future<int> loadSoundfontAsset({required String assetPath, int bank = 0, int program = 0}) async {
     final tempDir = await getTemporaryDirectory();
     final tempFile = File('${tempDir.path}/${assetPath.split('/').last}');
     if (!tempFile.existsSync()) {
       final byteData = await rootBundle.load(assetPath);
       final buffer = byteData.buffer;
-      await tempFile.writeAsBytes(
-          buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
+      await tempFile
+          .writeAsBytes(buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
     }
-    return FlutterMidiProPlatform.instance
-        .loadSoundfont(tempFile.path, bank, program);
+    return FlutterMidiProPlatform.instance.loadSoundfont(tempFile.path, bank, program);
   }
 
   /// Loads an additional SF2 into an existing synth instance (identified by [existingSfId]).
@@ -34,44 +45,58 @@ class MidiPro {
     if (!tempFile.existsSync()) {
       final byteData = await rootBundle.load(assetPath);
       final buffer = byteData.buffer;
-      await tempFile.writeAsBytes(
-          buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
+      await tempFile
+          .writeAsBytes(buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
     }
     return FlutterMidiProPlatform.instance
         .loadSoundfontIntoSynth(existingSfId, tempFile.path, bank, program);
   }
 
-  Future<int> loadSoundfontFile(
-      {required String filePath, int bank = 0, int program = 0}) async {
+  /// Loads a soundfont file from the specified file path.
+  /// Returns the sfId (SoundfontSamplerId).
+  Future<int> loadSoundfontFile({required String filePath, int bank = 0, int program = 0}) async {
     final tempDir = await getTemporaryDirectory();
     final tempFile = File('${tempDir.path}/${filePath.split('/').last}');
     if (!tempFile.existsSync()) {
       final file = File(filePath);
       await file.copy(tempFile.path);
     }
-    return FlutterMidiProPlatform.instance
-        .loadSoundfont(tempFile.path, bank, program);
+    return FlutterMidiProPlatform.instance.loadSoundfont(tempFile.path, bank, program);
   }
 
-  Future<int> loadSoundfontData(
-      {required Uint8List data, int bank = 0, int program = 0}) async {
+  /// Loads a soundfont file from the specified data.
+  /// Returns the sfId (SoundfontSamplerId).
+  Future<int> loadSoundfontData({required Uint8List data, int bank = 0, int program = 0}) async {
     final tempDir = await getTemporaryDirectory();
-    final randomTempFileName =
-        'soundfont_${DateTime.now().millisecondsSinceEpoch}.sf2';
+    final randomTempFileName = 'soundfont_${DateTime.now().millisecondsSinceEpoch}.sf2';
     final tempFile = File('${tempDir.path}/$randomTempFileName');
     tempFile.writeAsBytesSync(data);
-    return FlutterMidiProPlatform.instance
-        .loadSoundfont(tempFile.path, bank, program);
+    return FlutterMidiProPlatform.instance.loadSoundfont(tempFile.path, bank, program);
   }
 
+  /// Selects an instrument on the specified soundfont.
+  /// The soundfont ID is the ID returned by the [loadSoundfont] method.
+  /// The channel is a number from 1 to 16.
+  /// The bank number is the bank number of the instrument on the soundfont.
+  /// The program number is the program number of the instrument on the soundfont.
+  /// This is the same as the patch number.
+  /// If the soundfont does not have banks, set the bank number to 0.
   Future<void> selectInstrument({
+    /// The soundfont ID. First soundfont loaded is 1.
     required int sfId,
+
+    /// The program number of the instrument on the soundfont.
+    /// This is the same as the patch number.
     required int program,
+
+    /// The MIDI channel. This is a number from 0 to 15. Channel numbers start at 0.
     int channel = 0,
+
+    /// The bank number of the instrument on the soundfont. If the soundfont does not
+    /// have banks, set this to 0.
     int bank = 0,
   }) async {
-    return FlutterMidiProPlatform.instance
-        .selectInstrument(sfId, channel, bank, program);
+    return FlutterMidiProPlatform.instance.selectInstrument(sfId, channel, bank, program);
   }
 
   /// Select instrument using the fluidsynth-internal soundfont ID (from [loadSoundfontAssetIntoSynth]).
@@ -86,52 +111,91 @@ class MidiPro {
         .selectInstrumentBySfontId(sfId, channel, fluidSfontId, bank, program);
   }
 
+  /// Plays a note on the specified channel.
+  /// The channel is a number from 0 to 15.
+  /// The key is the MIDI note number. This is a number from 0 to 127.
+  /// The velocity is the velocity of the note. This is a number from 0 to 127.
+  /// A velocity of 127 is the maximum velocity.
+  /// The note will continue to play until it is stopped.
+  /// To stop the note, use the [stopNote] method.
   Future<void> playNote({
+    /// The MIDI channel. This is a number from 0 to 15. Channel numbers start at 0.
     int channel = 0,
+
+    /// The MIDI note number. This is a number from 0 to 127.
     required int key,
+
+    /// The velocity of the note. This is a number from 0 to 127.
     int velocity = 127,
+
+    /// The soundfont ID. First soundfont loaded is 1.
     int sfId = 1,
   }) async {
-    return FlutterMidiProPlatform.instance
-        .playNote(channel, key, velocity, sfId);
+    return FlutterMidiProPlatform.instance.playNote(channel, key, velocity, sfId);
   }
 
+  /// Stops a note on the specified channel.
+  /// The channel is a number from 0 to 15.
+  /// The key is the MIDI note number. This is a number from 0 to 127.
+  /// The note will stop playing.
+  /// To play the note again, use the [playNote] method.
+  /// To stop all notes on a channel, use the [stopAllNotes] method.
   Future<void> stopNote({
+    /// The MIDI channel. This is a number from 0 to 15. Channel numbers start at 0.
     int channel = 0,
+
+    /// The MIDI note number. This is a number from 0 to 127.
     required int key,
+
+    /// The soundfont ID. First soundfont loaded is 1.
     int sfId = 1,
   }) async {
     return FlutterMidiProPlatform.instance.stopNote(channel, key, sfId);
   }
 
-  Future<void> stopAllNotes({int sfId = 1}) async {
+  /// Stops all notes on the specified sfId.
+  Future<void> stopAllNotes({
+    /// The soundfont ID. First soundfont loaded is 1.
+    int sfId = 1,
+  }) async {
     return FlutterMidiProPlatform.instance.stopAllNotes(sfId);
   }
 
+  /// Sends a MIDI Control Change (CC) message to the specified channel on a soundfont.
+  /// [controller] is the CC number (0-127), [value] is the CC value (0-127).
   Future<void> controlChange({
     required int controller,
     required int value,
     int channel = 0,
     int sfId = 1,
   }) async {
-    return FlutterMidiProPlatform.instance
-        .controlChange(sfId, channel, controller, value);
+    return FlutterMidiProPlatform.instance.controlChange(sfId, channel, controller, value);
   }
 
+  /// Enables or disables sustain (MIDI CC 64) on the specified channel.
+  /// When [enabled] is true, sends value 127; when false, sends value 0.
   Future<void> setSustain({
     required bool enabled,
     int channel = 0,
     int sfId = 1,
   }) async {
     final value = enabled ? 127 : 0;
-    return controlChange(
-        controller: 64, value: value, channel: channel, sfId: sfId);
+    return controlChange(controller: 64, value: value, channel: channel, sfId: sfId);
   }
 
+  /// Unloads a soundfont from memory.
+  /// The soundfont ID is the ID returned by the [loadSoundfont] method.
+  /// If resetPresets is true, the presets will be reset to the default values.
   Future<void> unloadSoundfont(int sfId) async {
     return FlutterMidiProPlatform.instance.unloadSoundfont(sfId);
   }
 
+  /// Disposes of the FlutterMidiPro instance.
+  /// This should be called when the instance is no longer needed.
+  /// This will stop all notes and unload all soundfonts.
+  /// This will also release all resources used by the instance.
+  /// After disposing of the instance, the instance should not be used again.
+  ///
   Future<void> dispose() async {
     return FlutterMidiProPlatform.instance.dispose();
   }
@@ -153,8 +217,7 @@ class MidiPro {
     required int key,
     required int velocity,
   }) async {
-    return FlutterMidiProPlatform.instance
-        .scheduleNoteOn(sfId, tick, channel, key, velocity);
+    return FlutterMidiProPlatform.instance.scheduleNoteOn(sfId, tick, channel, key, velocity);
   }
 
   Future<void> scheduleNoteOff({
@@ -163,8 +226,7 @@ class MidiPro {
     required int channel,
     required int key,
   }) async {
-    return FlutterMidiProPlatform.instance
-        .scheduleNoteOff(sfId, tick, channel, key);
+    return FlutterMidiProPlatform.instance.scheduleNoteOff(sfId, tick, channel, key);
   }
 
   Future<void> deleteSequencer({required int sfId}) async {

--- a/lib/flutter_midi_pro.dart
+++ b/lib/flutter_midi_pro.dart
@@ -4,167 +4,170 @@ import 'package:flutter/services.dart';
 import 'package:flutter_midi_pro/flutter_midi_pro_platform_interface.dart';
 import 'package:path_provider/path_provider.dart';
 
-/// The FlutterMidiPro class provides functions for writing to and loading soundfont
-/// files, as well as playing and stopping MIDI notes.
-///
-/// To use this class, you must first call the [init] method. Then, you can load a
-/// soundfont file using the [loadSoundfont] method. After loading a soundfont file,
-/// you can select an instrument using the [selectInstrument] method. Finally, you
-/// can play and stop notes using the [playNote] and [stopNote] methods.
-///
-/// To stop all notes on a channel, you can use the [stopAllNotes] method.
-///
-/// To dispose of the FlutterMidiPro instance, you can use the [dispose] method.
 class MidiPro {
   MidiPro();
 
-  /// Loads a soundfont file from the specified asset path.
-  /// Returns the sfId (SoundfontSamplerId).
-  Future<int> loadSoundfontAsset({required String assetPath, int bank = 0, int program = 0}) async {
+  Future<int> loadSoundfontAsset(
+      {required String assetPath, int bank = 0, int program = 0}) async {
     final tempDir = await getTemporaryDirectory();
     final tempFile = File('${tempDir.path}/${assetPath.split('/').last}');
     if (!tempFile.existsSync()) {
       final byteData = await rootBundle.load(assetPath);
       final buffer = byteData.buffer;
-      await tempFile
-          .writeAsBytes(buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
+      await tempFile.writeAsBytes(
+          buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
     }
-    return FlutterMidiProPlatform.instance.loadSoundfont(tempFile.path, bank, program);
+    return FlutterMidiProPlatform.instance
+        .loadSoundfont(tempFile.path, bank, program);
   }
 
-  /// Loads a soundfont file from the specified file path.
-  /// Returns the sfId (SoundfontSamplerId).
-  Future<int> loadSoundfontFile({required String filePath, int bank = 0, int program = 0}) async {
+  /// Loads an additional SF2 into an existing synth instance (identified by [existingSfId]).
+  /// Returns the fluidsynth-internal soundfont ID (needed for [selectInstrumentBySfontId]).
+  Future<int> loadSoundfontAssetIntoSynth({
+    required int existingSfId,
+    required String assetPath,
+    int bank = 0,
+    int program = 0,
+  }) async {
+    final tempDir = await getTemporaryDirectory();
+    final tempFile = File('${tempDir.path}/${assetPath.split('/').last}');
+    if (!tempFile.existsSync()) {
+      final byteData = await rootBundle.load(assetPath);
+      final buffer = byteData.buffer;
+      await tempFile.writeAsBytes(
+          buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
+    }
+    return FlutterMidiProPlatform.instance
+        .loadSoundfontIntoSynth(existingSfId, tempFile.path, bank, program);
+  }
+
+  Future<int> loadSoundfontFile(
+      {required String filePath, int bank = 0, int program = 0}) async {
     final tempDir = await getTemporaryDirectory();
     final tempFile = File('${tempDir.path}/${filePath.split('/').last}');
     if (!tempFile.existsSync()) {
       final file = File(filePath);
       await file.copy(tempFile.path);
     }
-    return FlutterMidiProPlatform.instance.loadSoundfont(tempFile.path, bank, program);
+    return FlutterMidiProPlatform.instance
+        .loadSoundfont(tempFile.path, bank, program);
   }
 
-  /// Loads a soundfont file from the specified data.
-  /// Returns the sfId (SoundfontSamplerId).
-  Future<int> loadSoundfontData({required Uint8List data, int bank = 0, int program = 0}) async {
+  Future<int> loadSoundfontData(
+      {required Uint8List data, int bank = 0, int program = 0}) async {
     final tempDir = await getTemporaryDirectory();
-    final randomTempFileName = 'soundfont_${DateTime.now().millisecondsSinceEpoch}.sf2';
+    final randomTempFileName =
+        'soundfont_${DateTime.now().millisecondsSinceEpoch}.sf2';
     final tempFile = File('${tempDir.path}/$randomTempFileName');
     tempFile.writeAsBytesSync(data);
-    return FlutterMidiProPlatform.instance.loadSoundfont(tempFile.path, bank, program);
+    return FlutterMidiProPlatform.instance
+        .loadSoundfont(tempFile.path, bank, program);
   }
 
-  /// Selects an instrument on the specified soundfont.
-  /// The soundfont ID is the ID returned by the [loadSoundfont] method.
-  /// The channel is a number from 1 to 16.
-  /// The bank number is the bank number of the instrument on the soundfont.
-  /// The program number is the program number of the instrument on the soundfont.
-  /// This is the same as the patch number.
-  /// If the soundfont does not have banks, set the bank number to 0.
   Future<void> selectInstrument({
-    /// The soundfont ID. First soundfont loaded is 1.
     required int sfId,
-
-    /// The program number of the instrument on the soundfont.
-    /// This is the same as the patch number.
     required int program,
-
-    /// The MIDI channel. This is a number from 0 to 15. Channel numbers start at 0.
     int channel = 0,
-
-    /// The bank number of the instrument on the soundfont. If the soundfont does not
-    /// have banks, set this to 0.
     int bank = 0,
   }) async {
-    return FlutterMidiProPlatform.instance.selectInstrument(sfId, channel, bank, program);
+    return FlutterMidiProPlatform.instance
+        .selectInstrument(sfId, channel, bank, program);
   }
 
-  /// Plays a note on the specified channel.
-  /// The channel is a number from 0 to 15.
-  /// The key is the MIDI note number. This is a number from 0 to 127.
-  /// The velocity is the velocity of the note. This is a number from 0 to 127.
-  /// A velocity of 127 is the maximum velocity.
-  /// The note will continue to play until it is stopped.
-  /// To stop the note, use the [stopNote] method.
+  /// Select instrument using the fluidsynth-internal soundfont ID (from [loadSoundfontAssetIntoSynth]).
+  Future<void> selectInstrumentBySfontId({
+    required int sfId,
+    required int channel,
+    required int fluidSfontId,
+    int bank = 0,
+    int program = 0,
+  }) async {
+    return FlutterMidiProPlatform.instance
+        .selectInstrumentBySfontId(sfId, channel, fluidSfontId, bank, program);
+  }
+
   Future<void> playNote({
-    /// The MIDI channel. This is a number from 0 to 15. Channel numbers start at 0.
     int channel = 0,
-
-    /// The MIDI note number. This is a number from 0 to 127.
     required int key,
-
-    /// The velocity of the note. This is a number from 0 to 127.
     int velocity = 127,
-
-    /// The soundfont ID. First soundfont loaded is 1.
     int sfId = 1,
   }) async {
-    return FlutterMidiProPlatform.instance.playNote(channel, key, velocity, sfId);
+    return FlutterMidiProPlatform.instance
+        .playNote(channel, key, velocity, sfId);
   }
 
-  /// Stops a note on the specified channel.
-  /// The channel is a number from 0 to 15.
-  /// The key is the MIDI note number. This is a number from 0 to 127.
-  /// The note will stop playing.
-  /// To play the note again, use the [playNote] method.
-  /// To stop all notes on a channel, use the [stopAllNotes] method.
   Future<void> stopNote({
-    /// The MIDI channel. This is a number from 0 to 15. Channel numbers start at 0.
     int channel = 0,
-
-    /// The MIDI note number. This is a number from 0 to 127.
     required int key,
-
-    /// The soundfont ID. First soundfont loaded is 1.
     int sfId = 1,
   }) async {
     return FlutterMidiProPlatform.instance.stopNote(channel, key, sfId);
   }
 
-  /// Stops all notes on the specified sfId.
-  Future<void> stopAllNotes({
-    /// The soundfont ID. First soundfont loaded is 1.
-    int sfId = 1,
-  }) async {
+  Future<void> stopAllNotes({int sfId = 1}) async {
     return FlutterMidiProPlatform.instance.stopAllNotes(sfId);
   }
 
-  /// Sends a MIDI Control Change (CC) message to the specified channel on a soundfont.
-  /// [controller] is the CC number (0-127), [value] is the CC value (0-127).
   Future<void> controlChange({
     required int controller,
     required int value,
     int channel = 0,
     int sfId = 1,
   }) async {
-    return FlutterMidiProPlatform.instance.controlChange(sfId, channel, controller, value);
+    return FlutterMidiProPlatform.instance
+        .controlChange(sfId, channel, controller, value);
   }
 
-  /// Enables or disables sustain (MIDI CC 64) on the specified channel.
-  /// When [enabled] is true, sends value 127; when false, sends value 0.
   Future<void> setSustain({
     required bool enabled,
     int channel = 0,
     int sfId = 1,
   }) async {
     final value = enabled ? 127 : 0;
-    return controlChange(controller: 64, value: value, channel: channel, sfId: sfId);
+    return controlChange(
+        controller: 64, value: value, channel: channel, sfId: sfId);
   }
 
-  /// Unloads a soundfont from memory.
-  /// The soundfont ID is the ID returned by the [loadSoundfont] method.
-  /// If resetPresets is true, the presets will be reset to the default values.
   Future<void> unloadSoundfont(int sfId) async {
     return FlutterMidiProPlatform.instance.unloadSoundfont(sfId);
   }
 
-  /// Disposes of the FlutterMidiPro instance.
-  /// This should be called when the instance is no longer needed.
-  /// This will stop all notes and unload all soundfonts.
-  /// This will also release all resources used by the instance.
-  /// After disposing of the instance, the instance should not be used again.
-  ///
   Future<void> dispose() async {
     return FlutterMidiProPlatform.instance.dispose();
+  }
+
+  // Sequencer API
+
+  Future<void> createSequencer({required int sfId}) async {
+    return FlutterMidiProPlatform.instance.createSequencer(sfId);
+  }
+
+  Future<int> getSequencerTick({required int sfId}) async {
+    return FlutterMidiProPlatform.instance.getSequencerTick(sfId);
+  }
+
+  Future<void> scheduleNoteOn({
+    required int sfId,
+    required int tick,
+    required int channel,
+    required int key,
+    required int velocity,
+  }) async {
+    return FlutterMidiProPlatform.instance
+        .scheduleNoteOn(sfId, tick, channel, key, velocity);
+  }
+
+  Future<void> scheduleNoteOff({
+    required int sfId,
+    required int tick,
+    required int channel,
+    required int key,
+  }) async {
+    return FlutterMidiProPlatform.instance
+        .scheduleNoteOff(sfId, tick, channel, key);
+  }
+
+  Future<void> deleteSequencer({required int sfId}) async {
+    return FlutterMidiProPlatform.instance.deleteSequencer(sfId);
   }
 }

--- a/lib/flutter_midi_pro_method_channel.dart
+++ b/lib/flutter_midi_pro_method_channel.dart
@@ -9,16 +9,14 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
 
   @override
   Future<int> loadSoundfont(String path, int bank, int program) async {
-    final int sfId = await _channel.invokeMethod(
-        'loadSoundfont', {'path': path, 'bank': bank, 'program': program});
+    final int sfId = await _channel
+        .invokeMethod('loadSoundfont', {'path': path, 'bank': bank, 'program': program});
     return sfId;
   }
 
   @override
-  Future<int> loadSoundfontIntoSynth(
-      int existingSfId, String path, int bank, int program) async {
-    final int fluidSfId =
-        await _channel.invokeMethod('loadSoundfontIntoSynth', {
+  Future<int> loadSoundfontIntoSynth(int existingSfId, String path, int bank, int program) async {
+    final int fluidSfId = await _channel.invokeMethod('loadSoundfontIntoSynth', {
       'existingSfId': existingSfId,
       'path': path,
       'bank': bank,
@@ -28,15 +26,13 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
   }
 
   @override
-  Future<void> selectInstrument(
-      int sfId, int channel, int bank, int program) async {
-    await _channel.invokeMethod('selectInstrument',
-        {'sfId': sfId, 'channel': channel, 'bank': bank, 'program': program});
+  Future<void> selectInstrument(int sfId, int channel, int bank, int program) async {
+    await _channel.invokeMethod(
+        'selectInstrument', {'sfId': sfId, 'channel': channel, 'bank': bank, 'program': program});
   }
 
   @override
-  Future<void> selectInstrumentBySfontId(
-      int sfId, int channel, int fluidSfontId, int bank, int program) async {
+  Future<void> selectInstrumentBySfontId(int sfId, int channel, int fluidSfontId, int bank, int program) async {
     await _channel.invokeMethod('selectInstrumentBySfontId', {
       'sfId': sfId,
       'channel': channel,
@@ -48,14 +44,13 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
 
   @override
   Future<void> playNote(int channel, int key, int velocity, int sfId) async {
-    await _channel.invokeMethod('playNote',
-        {'channel': channel, 'key': key, 'velocity': velocity, 'sfId': sfId});
+    await _channel.invokeMethod(
+        'playNote', {'channel': channel, 'key': key, 'velocity': velocity, 'sfId': sfId});
   }
 
   @override
   Future<void> stopNote(int channel, int key, int sfId) async {
-    await _channel.invokeMethod(
-        'stopNote', {'channel': channel, 'key': key, 'sfId': sfId});
+    await _channel.invokeMethod('stopNote', {'channel': channel, 'key': key, 'sfId': sfId});
   }
 
   @override
@@ -64,8 +59,7 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
   }
 
   @override
-  Future<void> controlChange(
-      int sfId, int channel, int controller, int value) async {
+  Future<void> controlChange(int sfId, int channel, int controller, int value) async {
     await _channel.invokeMethod('controlChange', {
       'sfId': sfId,
       'channel': channel,
@@ -93,14 +87,12 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
 
   @override
   Future<int> getSequencerTick(int sfId) async {
-    final int tick =
-        await _channel.invokeMethod('getSequencerTick', {'sfId': sfId});
+    final int tick = await _channel.invokeMethod('getSequencerTick', {'sfId': sfId});
     return tick;
   }
 
   @override
-  Future<void> scheduleNoteOn(
-      int sfId, int tick, int channel, int key, int velocity) async {
+  Future<void> scheduleNoteOn(int sfId, int tick, int channel, int key, int velocity) async {
     await _channel.invokeMethod('scheduleNoteOn', {
       'sfId': sfId,
       'tick': tick,

--- a/lib/flutter_midi_pro_method_channel.dart
+++ b/lib/flutter_midi_pro_method_channel.dart
@@ -9,26 +9,53 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
 
   @override
   Future<int> loadSoundfont(String path, int bank, int program) async {
-    final int sfId = await _channel
-        .invokeMethod('loadSoundfont', {'path': path, 'bank': bank, 'program': program});
+    final int sfId = await _channel.invokeMethod(
+        'loadSoundfont', {'path': path, 'bank': bank, 'program': program});
     return sfId;
   }
 
   @override
-  Future<void> selectInstrument(int sfId, int channel, int bank, int program) async {
-    await _channel.invokeMethod(
-        'selectInstrument', {'sfId': sfId, 'channel': channel, 'bank': bank, 'program': program});
+  Future<int> loadSoundfontIntoSynth(
+      int existingSfId, String path, int bank, int program) async {
+    final int fluidSfId =
+        await _channel.invokeMethod('loadSoundfontIntoSynth', {
+      'existingSfId': existingSfId,
+      'path': path,
+      'bank': bank,
+      'program': program,
+    });
+    return fluidSfId;
+  }
+
+  @override
+  Future<void> selectInstrument(
+      int sfId, int channel, int bank, int program) async {
+    await _channel.invokeMethod('selectInstrument',
+        {'sfId': sfId, 'channel': channel, 'bank': bank, 'program': program});
+  }
+
+  @override
+  Future<void> selectInstrumentBySfontId(
+      int sfId, int channel, int fluidSfontId, int bank, int program) async {
+    await _channel.invokeMethod('selectInstrumentBySfontId', {
+      'sfId': sfId,
+      'channel': channel,
+      'fluidSfontId': fluidSfontId,
+      'bank': bank,
+      'program': program,
+    });
   }
 
   @override
   Future<void> playNote(int channel, int key, int velocity, int sfId) async {
-    await _channel.invokeMethod(
-        'playNote', {'channel': channel, 'key': key, 'velocity': velocity, 'sfId': sfId});
+    await _channel.invokeMethod('playNote',
+        {'channel': channel, 'key': key, 'velocity': velocity, 'sfId': sfId});
   }
 
   @override
   Future<void> stopNote(int channel, int key, int sfId) async {
-    await _channel.invokeMethod('stopNote', {'channel': channel, 'key': key, 'sfId': sfId});
+    await _channel.invokeMethod(
+        'stopNote', {'channel': channel, 'key': key, 'sfId': sfId});
   }
 
   @override
@@ -37,7 +64,8 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
   }
 
   @override
-  Future<void> controlChange(int sfId, int channel, int controller, int value) async {
+  Future<void> controlChange(
+      int sfId, int channel, int controller, int value) async {
     await _channel.invokeMethod('controlChange', {
       'sfId': sfId,
       'channel': channel,
@@ -54,5 +82,46 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
   @override
   Future<void> dispose() async {
     await _channel.invokeMethod('dispose');
+  }
+
+  // Sequencer API
+
+  @override
+  Future<void> createSequencer(int sfId) async {
+    await _channel.invokeMethod('createSequencer', {'sfId': sfId});
+  }
+
+  @override
+  Future<int> getSequencerTick(int sfId) async {
+    final int tick =
+        await _channel.invokeMethod('getSequencerTick', {'sfId': sfId});
+    return tick;
+  }
+
+  @override
+  Future<void> scheduleNoteOn(
+      int sfId, int tick, int channel, int key, int velocity) async {
+    await _channel.invokeMethod('scheduleNoteOn', {
+      'sfId': sfId,
+      'tick': tick,
+      'channel': channel,
+      'key': key,
+      'velocity': velocity,
+    });
+  }
+
+  @override
+  Future<void> scheduleNoteOff(int sfId, int tick, int channel, int key) async {
+    await _channel.invokeMethod('scheduleNoteOff', {
+      'sfId': sfId,
+      'tick': tick,
+      'channel': channel,
+      'key': key,
+    });
+  }
+
+  @override
+  Future<void> deleteSequencer(int sfId) async {
+    await _channel.invokeMethod('deleteSequencer', {'sfId': sfId});
   }
 }

--- a/lib/flutter_midi_pro_platform_interface.dart
+++ b/lib/flutter_midi_pro_platform_interface.dart
@@ -16,20 +16,16 @@ abstract class FlutterMidiProPlatform extends PlatformInterface {
     throw UnimplementedError('loadSoundfont() has not been implemented.');
   }
 
-  Future<int> loadSoundfontIntoSynth(
-      int existingSfId, String path, int bank, int program) {
-    throw UnimplementedError(
-        'loadSoundfontIntoSynth() has not been implemented.');
+  Future<int> loadSoundfontIntoSynth(int existingSfId, String path, int bank, int program) {
+    throw UnimplementedError('loadSoundfontIntoSynth() has not been implemented.');
   }
 
   Future<void> selectInstrument(int sfId, int channel, int bank, int program) {
     throw UnimplementedError('selectInstrument() has not been implemented.');
   }
 
-  Future<void> selectInstrumentBySfontId(
-      int sfId, int channel, int fluidSfontId, int bank, int program) {
-    throw UnimplementedError(
-        'selectInstrumentBySfontId() has not been implemented.');
+  Future<void> selectInstrumentBySfontId(int sfId, int channel, int fluidSfontId, int bank, int program) {
+    throw UnimplementedError('selectInstrumentBySfontId() has not been implemented.');
   }
 
   Future<void> playNote(int channel, int key, int velocity, int sfId) {
@@ -44,6 +40,8 @@ abstract class FlutterMidiProPlatform extends PlatformInterface {
     throw UnimplementedError('stopAllNotes() has not been implemented.');
   }
 
+  /// Sends a MIDI Control Change (CC) message to the specified channel on a soundfont.
+  /// [controller] is the CC number (0-127), [value] is the CC value (0-127).
   Future<void> controlChange(int sfId, int channel, int controller, int value) {
     throw UnimplementedError('controlChange() has not been implemented.');
   }
@@ -66,8 +64,7 @@ abstract class FlutterMidiProPlatform extends PlatformInterface {
     throw UnimplementedError('getSequencerTick() has not been implemented.');
   }
 
-  Future<void> scheduleNoteOn(
-      int sfId, int tick, int channel, int key, int velocity) {
+  Future<void> scheduleNoteOn(int sfId, int tick, int channel, int key, int velocity) {
     throw UnimplementedError('scheduleNoteOn() has not been implemented.');
   }
 

--- a/lib/flutter_midi_pro_platform_interface.dart
+++ b/lib/flutter_midi_pro_platform_interface.dart
@@ -16,8 +16,20 @@ abstract class FlutterMidiProPlatform extends PlatformInterface {
     throw UnimplementedError('loadSoundfont() has not been implemented.');
   }
 
+  Future<int> loadSoundfontIntoSynth(
+      int existingSfId, String path, int bank, int program) {
+    throw UnimplementedError(
+        'loadSoundfontIntoSynth() has not been implemented.');
+  }
+
   Future<void> selectInstrument(int sfId, int channel, int bank, int program) {
     throw UnimplementedError('selectInstrument() has not been implemented.');
+  }
+
+  Future<void> selectInstrumentBySfontId(
+      int sfId, int channel, int fluidSfontId, int bank, int program) {
+    throw UnimplementedError(
+        'selectInstrumentBySfontId() has not been implemented.');
   }
 
   Future<void> playNote(int channel, int key, int velocity, int sfId) {
@@ -32,8 +44,6 @@ abstract class FlutterMidiProPlatform extends PlatformInterface {
     throw UnimplementedError('stopAllNotes() has not been implemented.');
   }
 
-  /// Sends a MIDI Control Change (CC) message to the specified channel on a soundfont.
-  /// [controller] is the CC number (0-127), [value] is the CC value (0-127).
   Future<void> controlChange(int sfId, int channel, int controller, int value) {
     throw UnimplementedError('controlChange() has not been implemented.');
   }
@@ -44,5 +54,28 @@ abstract class FlutterMidiProPlatform extends PlatformInterface {
 
   Future<void> dispose() {
     throw UnimplementedError('dispose() has not been implemented.');
+  }
+
+  // Sequencer API
+
+  Future<void> createSequencer(int sfId) {
+    throw UnimplementedError('createSequencer() has not been implemented.');
+  }
+
+  Future<int> getSequencerTick(int sfId) {
+    throw UnimplementedError('getSequencerTick() has not been implemented.');
+  }
+
+  Future<void> scheduleNoteOn(
+      int sfId, int tick, int channel, int key, int velocity) {
+    throw UnimplementedError('scheduleNoteOn() has not been implemented.');
+  }
+
+  Future<void> scheduleNoteOff(int sfId, int tick, int channel, int key) {
+    throw UnimplementedError('scheduleNoteOff() has not been implemented.');
+  }
+
+  Future<void> deleteSequencer(int sfId) {
+    throw UnimplementedError('deleteSequencer() has not been implemented.');
   }
 }


### PR DESCRIPTION
Adds two capabilities that enable sample-accurate MIDI scheduling and loading multiple soundfonts into a single synth instance.

## Multi-soundfont support (2 methods)

  - loadSoundfontIntoSynth — loads an additional SF2 into an existing synth,
  returning the fluidsynth-internal sfont ID
  - selectInstrumentBySfontId — selects an instrument using that internal ID

Currently each loadSoundfont call creates a separate fluidsynth synth + audio driver. If you need two soundfonts on different channels of the same synth (e.g. piano on ch0, percussion on ch1), there's no way to do it — you get two independent audio pipelines that can't share channels or timing. These methods let you load a second SF2 into an existing synth so both instruments share the same audio output and sample clock.

## Sequencer API (5 methods)

  - createSequencer / deleteSequencer — lifecycle management
  - getSequencerTick — read current sequencer tick
  - scheduleNoteOn / scheduleNoteOff — schedule events at exact tick positions

Fluidsynth has a built-in sequencer that dispatches MIDI events on the audio thread with sample-accurate timing. Without it, the only option is calling playNote/stopNote from Dart, which goes through the method channel (adds ~1-3ms jitter) and is subject to Dart's event loop scheduling. The sequencer eliminates it entirely.

## Use case

I built these for a [practice tool app](https://github.com/brenzi/practice-tool-app) that plays random piano notes on a metronome grid. I want the metronome click and piano note have sample-accurate timing. We want to make real-time changes to what should be played on the fly without disrupting the timing. Also, both soundfonts need to share a synth so channel routing works. Neither was possible with the existing API.

## Disclosure

This PR made extensive use of an AI coding agent but a human was in the loop.