### PR TITLE
feat: add playback tuning API and fix macOS startup build failure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "java.configuration.updateBuildConfiguration": "interactive",
-    "cmake.sourceDirectory": "C:/Users/Melih/VSCodeFlutterProjects/flutter_midi_pro/example/windows"
+    "cmake.sourceDirectory": "C:/Users/Melih/VSCodeFlutterProjects/flutter_midi_pro/example/windows",
 }

--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -1,6 +1,7 @@
 #include <jni.h>
 #include <fluidsynth.h>
 #include <unistd.h>
+#include <cmath>
 #include <map>
 
 std::map<int, fluid_synth_t*> synths = {};
@@ -8,6 +9,41 @@ std::map<int, fluid_audio_driver_t*> drivers = {};
 std::map<int, fluid_settings_t*> settings = {};
 std::map<int, int> soundfonts = {};
 int nextSfId = 1;
+
+static const double kDefaultPlaybackStandardA4 = 440.0;
+static const int kTuningBank = 0;
+static const int kTuningProg = 0;
+double playbackStandardA4 = kDefaultPlaybackStandardA4;
+
+// FluidSynth key tuning uses cents (100 per semitone), not Hz.
+// Equal temperament: pitch[i] == i * 100.0; shift all keys by A4 offset vs 440 Hz.
+static void applyPlaybackStandard(fluid_synth_t* synth, double a4Hz) {
+    double pitch[128];
+    const double centsOffset = 1200.0 * log2(a4Hz / kDefaultPlaybackStandardA4);
+    for (int i = 0; i < 128; i++) {
+        pitch[i] = i * 100.0 + centsOffset;
+    }
+    fluid_synth_activate_key_tuning(synth, kTuningBank, kTuningProg, "Playback", pitch, 1);
+    for (int ch = 0; ch < 16; ch++) {
+        fluid_synth_activate_tuning(synth, ch, kTuningBank, kTuningProg, 1);
+    }
+}
+
+static void resetSynthTuning(fluid_synth_t* synth) {
+    for (int ch = 0; ch < 16; ch++) {
+        fluid_synth_deactivate_tuning(synth, ch, 1);
+    }
+}
+
+static void applyPlaybackStandardToAll() {
+    for (auto const& entry : synths) {
+        if (fabs(playbackStandardA4 - kDefaultPlaybackStandardA4) < 0.001) {
+            resetSynthTuning(entry.second);
+        } else {
+            applyPlaybackStandard(entry.second, playbackStandardA4);
+        }
+    }
+}
 
 extern "C" JNIEXPORT int JNICALL
 Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_loadSoundfont(JNIEnv* env, jclass clazz, jstring path, jint bank, jint program) {
@@ -30,6 +66,9 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_loadSoundfont(
     // Audio driver'ı en son oluştur
     drivers[nextSfId] = new_fluid_audio_driver(settings[nextSfId], synths[nextSfId]);
     soundfonts[nextSfId] = sfId;
+    if (fabs(playbackStandardA4 - kDefaultPlaybackStandardA4) >= 0.001) {
+        applyPlaybackStandard(synths[nextSfId], playbackStandardA4);
+    }
     nextSfId++;
     return nextSfId - 1;
 }
@@ -84,4 +123,22 @@ Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_dispose(JNIEnv
     synths.clear();
     drivers.clear();
     soundfonts.clear();
+    playbackStandardA4 = kDefaultPlaybackStandardA4;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_setPlaybackStandard(JNIEnv* env, jclass clazz, jdouble standard) {
+    playbackStandardA4 = standard;
+    applyPlaybackStandardToAll();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_resetPlaybackStandard(JNIEnv* env, jclass clazz) {
+    playbackStandardA4 = kDefaultPlaybackStandardA4;
+    applyPlaybackStandardToAll();
+}
+
+extern "C" JNIEXPORT jdouble JNICALL
+Java_com_melihhakanpektas_flutter_1midi_1pro_FlutterMidiProPlugin_getPlaybackStandard(JNIEnv* env, jclass clazz) {
+    return playbackStandardA4;
 }

--- a/android/src/main/kotlin/com/melihhakanpektas/flutter_midi_pro/FlutterMidiProPlugin.kt
+++ b/android/src/main/kotlin/com/melihhakanpektas/flutter_midi_pro/FlutterMidiProPlugin.kt
@@ -40,6 +40,18 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
     private external fun unloadSoundfont(sfId: Int)
     @JvmStatic
     private external fun dispose()
+
+    @JvmStatic
+    private external fun setPlaybackStandard(standard: Double)
+
+    @JvmStatic
+    private external fun resetPlaybackStandard()
+
+    @JvmStatic
+    private external fun getPlaybackStandard(): Double
+
+    private const val MIN_PLAYBACK_STANDARD = 400.0
+    private const val MAX_PLAYBACK_STANDARD = 480.0
   }
 
   private lateinit var channel : MethodChannel
@@ -135,6 +147,22 @@ class FlutterMidiProPlugin: FlutterPlugin, MethodCallHandler {
       "dispose" -> {
         dispose()
         result.success(null)
+      }
+      "setPlaybackStandard" -> {
+        val standard = call.argument<Double>("standard")
+        if (standard == null || standard < MIN_PLAYBACK_STANDARD || standard > MAX_PLAYBACK_STANDARD) {
+          result.error("INVALID_ARGUMENT", "standard must be between 400 and 480", null)
+          return
+        }
+        setPlaybackStandard(standard)
+        result.success(null)
+      }
+      "resetPlaybackStandard" -> {
+        resetPlaybackStandard()
+        result.success(null)
+      }
+      "getPlaybackStandard" -> {
+        result.success(getPlaybackStandard())
       }
       else -> result.notImplemented()
     }

--- a/ios/Classes/FlutterMidiProPlugin.swift
+++ b/ios/Classes/FlutterMidiProPlugin.swift
@@ -5,10 +5,28 @@ import AVFoundation
 import CoreAudio
 
 public class FlutterMidiProPlugin: NSObject, FlutterPlugin {
+  private static let defaultPlaybackStandardA4 = 440.0
+  private static let minPlaybackStandard = 400.0
+  private static let maxPlaybackStandard = 480.0
+
   var audioEngines: [Int: [AVAudioEngine]] = [:]
   var soundfontIndex = 1
   var soundfontSamplers: [Int: [AVAudioUnitSampler]] = [:]
   var soundfontURLs: [Int: URL] = [:]
+  var playbackStandardA4 = defaultPlaybackStandardA4
+
+  private func globalTuningCents(for a4Hz: Double) -> Float {
+    return Float(1200.0 * log2(a4Hz / Self.defaultPlaybackStandardA4))
+  }
+
+  private func applyPlaybackStandardToAllSamplers() {
+    let cents = globalTuningCents(for: playbackStandardA4)
+    for (_, samplers) in soundfontSamplers {
+      for sampler in samplers {
+        sampler.globalTuning = cents
+      }
+    }
+  }
   
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_midi_pro", binaryMessenger: registrar.messenger())
@@ -107,6 +125,7 @@ public class FlutterMidiProPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: "SOUND_FONT_LOAD_FAILED1", message: "Failed to load soundfont", details: nil))
                 return
             }
+            sampler.globalTuning = globalTuningCents(for: playbackStandardA4)
             chSamplers.append(sampler)
             chAudioEngines.append(audioEngine)
         }
@@ -203,7 +222,24 @@ public class FlutterMidiProPlugin: NSObject, FlutterPlugin {
         }
         audioEngines = [:]
         soundfontSamplers = [:]
+        playbackStandardA4 = Self.defaultPlaybackStandardA4
         result(nil)
+    case "setPlaybackStandard":
+        let args = call.arguments as! [String: Any]
+        let standard = args["standard"] as! Double
+        if standard < Self.minPlaybackStandard || standard > Self.maxPlaybackStandard {
+            result(FlutterError(code: "INVALID_ARGUMENT", message: "standard must be between 400 and 480", details: nil))
+            return
+        }
+        playbackStandardA4 = standard
+        applyPlaybackStandardToAllSamplers()
+        result(nil)
+    case "resetPlaybackStandard":
+        playbackStandardA4 = Self.defaultPlaybackStandardA4
+        applyPlaybackStandardToAllSamplers()
+        result(nil)
+    case "getPlaybackStandard":
+        result(playbackStandardA4)
     default:
       result(FlutterMethodNotImplemented)
         break

--- a/lib/flutter_midi_pro.dart
+++ b/lib/flutter_midi_pro.dart
@@ -18,6 +18,15 @@ import 'package:path_provider/path_provider.dart';
 class MidiPro {
   MidiPro();
 
+  /// Default A4 reference frequency (Hz) for equal-temperament playback.
+  static const double defaultPlaybackStandard = 440.0;
+
+  /// Minimum allowed A4 reference frequency (Hz).
+  static const double minPlaybackStandard = 400.0;
+
+  /// Maximum allowed A4 reference frequency (Hz).
+  static const double maxPlaybackStandard = 480.0;
+
   /// Loads a soundfont file from the specified asset path.
   /// Returns the sfId (SoundfontSamplerId).
   Future<int> loadSoundfontAsset({required String assetPath, int bank = 0, int program = 0}) async {
@@ -156,6 +165,41 @@ class MidiPro {
   /// If resetPresets is true, the presets will be reset to the default values.
   Future<void> unloadSoundfont(int sfId) async {
     return FlutterMidiProPlatform.instance.unloadSoundfont(sfId);
+  }
+
+  /// Sets the A4 reference frequency (Hz) for playback tuning.
+  ///
+  /// Can be called at any time: before or after loading a soundfont, and while
+  /// playing. Already-loaded soundfonts are updated immediately on both Android
+  /// and iOS. Soundfonts loaded later automatically use the current standard.
+  ///
+  /// New [playNote] calls use the updated tuning. Notes already sounding may
+  /// keep the previous pitch until they are released and played again (platform
+  /// dependent; iOS often retunes sustained notes immediately).
+  ///
+  /// [standard] must be between [minPlaybackStandard] and [maxPlaybackStandard].
+  Future<void> setPlaybackStandard(double standard) async {
+    if (standard < minPlaybackStandard || standard > maxPlaybackStandard) {
+      throw ArgumentError.value(
+        standard,
+        'standard',
+        'Must be between $minPlaybackStandard and $maxPlaybackStandard Hz',
+      );
+    }
+    return FlutterMidiProPlatform.instance.setPlaybackStandard(standard);
+  }
+
+  /// Resets playback tuning to [defaultPlaybackStandard] (440 Hz A4).
+  ///
+  /// Like [setPlaybackStandard], this can be called at any time and applies to
+  /// all loaded soundfonts immediately.
+  Future<void> resetPlaybackStandard() async {
+    return FlutterMidiProPlatform.instance.resetPlaybackStandard();
+  }
+
+  /// Returns the current A4 reference frequency (Hz) used for playback tuning.
+  Future<double> getPlaybackStandard() async {
+    return FlutterMidiProPlatform.instance.getPlaybackStandard();
   }
 
   /// Disposes of the FlutterMidiPro instance.

--- a/lib/flutter_midi_pro_method_channel.dart
+++ b/lib/flutter_midi_pro_method_channel.dart
@@ -55,4 +55,20 @@ class MethodChannelFlutterMidiPro extends FlutterMidiProPlatform {
   Future<void> dispose() async {
     await _channel.invokeMethod('dispose');
   }
+
+  @override
+  Future<void> setPlaybackStandard(double standard) async {
+    await _channel.invokeMethod('setPlaybackStandard', {'standard': standard});
+  }
+
+  @override
+  Future<void> resetPlaybackStandard() async {
+    await _channel.invokeMethod('resetPlaybackStandard');
+  }
+
+  @override
+  Future<double> getPlaybackStandard() async {
+    final standard = await _channel.invokeMethod<double>('getPlaybackStandard');
+    return standard ?? 440.0;
+  }
 }

--- a/lib/flutter_midi_pro_platform_interface.dart
+++ b/lib/flutter_midi_pro_platform_interface.dart
@@ -45,4 +45,19 @@ abstract class FlutterMidiProPlatform extends PlatformInterface {
   Future<void> dispose() {
     throw UnimplementedError('dispose() has not been implemented.');
   }
+
+  /// Sets the A4 reference frequency (Hz) used for playback tuning.
+  Future<void> setPlaybackStandard(double standard) {
+    throw UnimplementedError('setPlaybackStandard() has not been implemented.');
+  }
+
+  /// Resets playback tuning to the default A4 = 440 Hz standard.
+  Future<void> resetPlaybackStandard() {
+    throw UnimplementedError('resetPlaybackStandard() has not been implemented.');
+  }
+
+  /// Returns the current A4 reference frequency (Hz) used for playback tuning.
+  Future<double> getPlaybackStandard() {
+    throw UnimplementedError('getPlaybackStandard() has not been implemented.');
+  }
 }

--- a/macos/Classes/FlutterMidiProPlugin.swift
+++ b/macos/Classes/FlutterMidiProPlugin.swift
@@ -18,52 +18,25 @@ public class FlutterMidiProPlugin: NSObject, FlutterPlugin {
   
   public override init() {
     super.init()
-    setupAudioSessionNotifications()
+    setupAudioEngineNotifications()
   }
   
   deinit {
     NotificationCenter.default.removeObserver(self)
   }
   
-  private func setupAudioSessionNotifications() {
-    // On macOS, we also listen for interruptions but they're less common
-    // AVAudioSession is available on macOS 10.15+
-    if #available(macOS 10.15, *) {
-      NotificationCenter.default.addObserver(
-        self,
-        selector: #selector(handleAudioSessionInterruption),
-        name: AVAudioSession.interruptionNotification,
-        object: AVAudioSession.sharedInstance()
-      )
-    }
+  private func setupAudioEngineNotifications() {
+    // AVAudioSession is iOS-only; on macOS listen for engine configuration changes instead.
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleAudioEngineConfigurationChange),
+      name: .AVAudioEngineConfigurationChange,
+      object: nil
+    )
   }
   
-  @objc private func handleAudioSessionInterruption(notification: Notification) {
-    guard let userInfo = notification.userInfo,
-          let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-          let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
-      return
-    }
-    
-    switch type {
-    case .began:
-      // Interruption began - audio engines will be stopped automatically by the system
-      break
-    case .ended:
-      // Interruption ended - restart all audio engines
-      // Check if we should resume (if option is present and true, or if option is missing)
-      var shouldResume = true
-      if let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt {
-        let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-        shouldResume = options.contains(.shouldResume)
-      }
-      
-      if shouldResume {
-        restartAudioEngines()
-      }
-    @unknown default:
-      break
-    }
+  @objc private func handleAudioEngineConfigurationChange(notification: Notification) {
+    restartAudioEngines()
   }
   
   private func restartAudioEngines() {


### PR DESCRIPTION
## Summary

本 PR 包含两项改动：

1. **新增播放变调（Playback Standard）API**  
   支持在运行时设置 A4 参考频率（400–480 Hz），用于调整整体播放音高，默认仍为 440 Hz。

2. **修复 macOS 编译/启动失败**  
   移除 macOS 上对 `AVAudioSession` 的错误使用（该 API 仅 iOS 可用），改用 `AVAudioEngineConfigurationChange` 监听音频配置变化并自动重启音频引擎。

## Changes

### 1. 播放变调功能（`63d6116`）

**Dart 层新增 API：**
- `MidiPro.setPlaybackStandard(double standard)` — 设置 A4 参考频率
- `MidiPro.resetPlaybackStandard()` — 重置为 440 Hz
- `MidiPro.getPlaybackStandard()` — 获取当前 A4 频率
- 常量：`defaultPlaybackStandard` (440)、`minPlaybackStandard` (400)、`maxPlaybackStandard` (480)

**平台实现：**
| 平台 | 实现方式 |
|------|----------|
| **Android** | FluidSynth `fluid_synth_activate_key_tuning`，通过 cents 偏移实现等律变调 |
| **iOS** | `AVAudioUnitSampler.globalTuning`，基于 `log2(a4/440)` 计算 cents |
| **macOS** | 本次未实现变调 API（仅修复启动问题） |

**行为说明：**
- 可在加载 soundfont 前/后、播放过程中随时调用
- 已加载的 soundfont 会立即应用新音高
- 后续新加载的 soundfont 自动使用当前标准
- `dispose()` 时会重置为 440 Hz

### 2. macOS 启动修复（`1f9b345`）

**问题：**  
macOS 插件误用 `AVAudioSession.interruptionNotification`，导致编译报错：